### PR TITLE
[ GET BINARIES ] change mathcing pattern from link to file

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -71,7 +71,6 @@
 
 - name: "get binaries"
   find:
-    file_type: link
     paths: "{{ imagemagick_install_path }}/bin/"
   register: imagemagick_binaries
   tags: imagemagick

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -71,7 +71,10 @@
 
 - name: "get binaries"
   find:
+    file_type: any
     paths: "{{ imagemagick_install_path }}/bin/"
+    patterns: "^[a-z]+"
+    use_regex: yes
   register: imagemagick_binaries
   tags: imagemagick
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/17009998/56889496-22dfe480-6a7f-11e9-98f2-eb93d6a89434.png)


![image](https://user-images.githubusercontent.com/17009998/56889610-81a55e00-6a7f-11e9-93c3-f57034513d22.png)


Tried to install 6.8.9 version of ImageMagick and linking was failed due to wrong pattern matching in get binaries step.
```yml
imagemagick_version: "6.8.9"
```